### PR TITLE
fixed portfolio overlap

### DIFF
--- a/client/src/components/PortfolioCard/PortfolioCard.js
+++ b/client/src/components/PortfolioCard/PortfolioCard.js
@@ -4,7 +4,7 @@ const PortfolioCard = ({ id, name, alt, image, description, survey }) => (
   <div className="row" style={{padding: "20px"}}>
     <div className="col-md-7">
       <a href="#">
-        <img className="img-fluid rounded mb-3 mb-md-0" src={ image } alt={ alt } />
+        <img className="img-fluid rounded mb-2 mb-md-0" src={ image } alt={ alt } />
       </a>
     </div>
     <div className="col-md-5">


### PR DESCRIPTION
fixed bug that was making sponsor images overlap with the description text
![new_screenshot](https://user-images.githubusercontent.com/35998407/47034858-7bd0d680-d146-11e8-8bcc-d94c13499b8f.png)
